### PR TITLE
[#15] Add hash256 to api256

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: rust
 rust:
-- 1.29.1
+- 1.30.0
 
 # all unlabeled jobs run at test. Only if all "test" jobs finish, will the publish job run
 stages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1
+
+### Added
++ `Api256.hash256(hashable_buffer: Buffer): Buffer;`
+
 ## 0.4.0
 
 ### Breaking Changes
@@ -25,7 +30,7 @@ None
 
 ### Changed
 
-+ Updated to `rerypt-rs` 0.3.0.
++ Updated to `recrypt-rs` 0.3.0.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.4.1
 
 ### Added
-+ `Api256.hash256(hashable_buffer: Buffer): Buffer;`
++ `Api256.hash256(hashable_buffer: Buffer): Buffer;` Note that the returned `Buffer` will always be _exactly_ 32 bytes.
 
 ## 0.4.0
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,7 @@ export class Api256 {
     generatePlaintext(): Plaintext;
     generateTransformKey(fromPrivateKey: PrivateKey, toPublicKey: PublicKey, privateSigningKey: PrivateSigningKey): TransformKey;
     computePublicKey(privateKey: PrivateKey): PublicKey;
+    hash256(hashable_buffer: Buffer): Buffer;
     deriveSymmetricKey(plaintext: Plaintext): Buffer;
     encrypt(plaintext: Plaintext, toPublicKey: PublicKey, privateSigningKey: PrivateSigningKey): EncryptedValue;
     transform(encryptedValue: EncryptedValue, transformKey: TransformKey, privateSigningKey: PrivateSigningKey): EncryptedValue;

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recrypt-node-binding"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["IronCore Labs <code@ironcorelabs.com>"]
 
 [lib]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -9,7 +9,8 @@ crate-type = ["dylib"]
 
 [dependencies]
 rand = "0.5.5"
-recrypt = "0.3.0"
+#recrypt = "0.3.0"
+recrypt = { git = "https://github.com/IronCoreLabs/recrypt-rs"}
 neon = "0.2.0"
 
 [build-dependencies]

--- a/native/src/api256.rs
+++ b/native/src/api256.rs
@@ -136,6 +136,19 @@ declare_types! {
             Ok(util::public_key_to_js_object(&mut cx, &derived_public_key)?.upcast())
         }
 
+        method hash256(mut cx) {
+            let hashable_buffer: Handle<JsBuffer> = cx.argument::<JsBuffer>(0)?;
+
+            let hashed_bytes = {
+                let mut this = cx.this();
+                let guard = cx.lock();
+                let mut recrypt_api_256 = this.borrow_mut(&guard);
+                recrypt_api_256.api.hash_256(&util::buffer_to_variable_bytes(&cx, hashable_buffer))
+            };
+
+            Ok(util::bytes_to_buffer(&mut cx, &hashed_bytes)?.upcast())
+        }
+
         method deriveSymmetricKey(mut cx){
             let plaintext_buffer: Handle<JsBuffer> = cx.argument::<JsBuffer>(0)?;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ironcorelabs/recrypt-node-binding",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Bindings to allow the recrypt-rs library to work via NodeJS.",
     "repository": {
         "type": "git",

--- a/test/recrypt-node.test.js
+++ b/test/recrypt-node.test.js
@@ -122,6 +122,15 @@ describe("Recrypt-Node", () => {
             });
         });
 
+        describe("hash256", () => {
+            test("should return 32 bytes for plaintext", () => {
+                const pt = api.generatePlaintext();
+                const symmetricKey = api.hash256(pt);
+                expect(symmetricKey).toBeInstanceOf(Buffer);
+                expect(symmetricKey).toHaveLength(32);
+            });
+        });
+
         describe("deriveSymmetricKey", () => {
             test("should return symmetric key from plaintext", () => {
                 const pt = api.generatePlaintext();


### PR DESCRIPTION
see #15 

## TODO
* Cargo.toml currently pointed to `recrypt master` as hash_256 has not been released.

## Changelog
* added hash256 to api256
* bump Travis to rust 1.30.0