### PR TITLE
Add node 14 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,36 @@ jobs:
               - rustup target add x86_64-pc-windows-msvc
               - source .travis_scripts/maybe-install-node.sh
           if: tag =~ /^\d+\.\d+\.\d+/ OR branch = main OR type = pull_request
+          - name: "Linux - Node 14 - glibc"
+          os: linux
+          env:
+              - TRAVIS_NODE_VERSION="14"
+              - SKIP_DEPLOY=0
+          if: tag =~ /^\d+\.\d+\.\d+/ OR branch = main OR type = pull_request
+        - name: "Linux - Node 14 - musl"
+          os: linux
+          env:
+              - SKIP_DEPLOY=0
+              - IMAGE=14-alpine
+              - INDOCKER="docker exec target"
+          if: tag =~ /^\d+\.\d+\.\d+/ OR branch = main OR type = pull_request
+        - name: "OSX - Node 14"
+          os: osx
+          env:
+              - TRAVIS_NODE_VERSION="14"
+              - SKIP_DEPLOY=0
+          if: tag =~ /^\d+\.\d+\.\d+/ OR branch = main OR type = pull_request
+        - name: "Windows - Node 14"
+          os: windows
+          env:
+              # Stop Windows builds from hanging after completion https://travis-ci.community/t/timeout-after-build-finished-and-succeeded/1336
+              - YARN_GPG=no
+              - TRAVIS_NODE_VERSION="14"
+              - SKIP_DEPLOY=0
+          install:
+              - rustup target add x86_64-pc-windows-msvc
+              - source .travis_scripts/maybe-install-node.sh
+          if: tag =~ /^\d+\.\d+\.\d+/ OR branch = main OR type = pull_request
         # Publish to npm only on release tag
         - stage: publish
           name: "Publish to npm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ jobs:
           name: "Publish to npm"
           os: linux
           env:
-              - TRAVIS_NODE_VERSION="10"
+              - TRAVIS_NODE_VERSION="14"
               - SKIP_DEPLOY=1
 
               # NPM_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-    - 1.41.0
+    - 1.48.0
 
 services:
     - docker
@@ -77,7 +77,7 @@ jobs:
               - rustup target add x86_64-pc-windows-msvc
               - source .travis_scripts/maybe-install-node.sh
           if: tag =~ /^\d+\.\d+\.\d+/ OR branch = main OR type = pull_request
-          - name: "Linux - Node 14 - glibc"
+        - name: "Linux - Node 14 - glibc"
           os: linux
           env:
               - TRAVIS_NODE_VERSION="14"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,24 @@
+## 0.7.3
+
+### Breaking Changes
+
+None
+
+### Changed
+
+-   Added support for Node 14.
+
 ## 0.7.2
 
 ### Changed
 
-- Updated all JS and Rust library dependencies
+-   Updated all JS and Rust library dependencies
 
 ## 0.7.1
 
 ### Changed
 
-- Added support for Node 10/12 on Windows
+-   Added support for Node 10/12 on Windows
 
 ## 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@ This library uses the [Neon Bindings](https://www.neon-bindings.com) toolchain t
 
 ## Supported Platforms
 
-|                       | Node 10 | Node 12 |
-| --------------------- | ------- | ------- |
-| Linux x64 - glibc     | ✓       | ✓       |
-| Linux x64 - musl-libc | ✓       | ✓       |
-| OSX x64               | ✓       | ✓       |
-| Windows x64           | ✓       | ✓       |
-| Windows x64           | ✓       | ✓       |
+|                       | Node 10 | Node 12 | Node 14 |
+| --------------------- | ------- | ------- | ------- |
+| Linux x64 - glibc     | ✓       | ✓       | ✓       |
+| Linux x64 - musl-libc | ✓       | ✓       | ✓       |
+| OSX x64               | ✓       | ✓       | ✓       |
+| Windows x64           | ✓       | ✓       | ✓       |
 
 ## Install
 
@@ -108,7 +107,7 @@ npm run compile
 or
 
 ```
-yarn run compile
+yarn compile
 ```
 
 This will produce an `index.node` file within the `native` directory. This file can then be included within a NodeJS file by simply requiring the file, e.g.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ironcorelabs/recrypt-node-binding",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "description": "Bindings to allow the recrypt-rs library to work via NodeJS.",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Node 14 is the current LTS, and Node 10 is leaving its maintenance window at the end of the month. Keeping it supported for now, so this is a pre-1.0 patch bump.