### PR TITLE
CI fixes

### DIFF
--- a/.github/typescript-ci-patch.yaml
+++ b/.github/typescript-ci-patch.yaml
@@ -44,7 +44,7 @@
 # Only check coverage in one of the matrix job instances.
 - op: add
   path: /jobs/test/steps/7/if
-  value: ${{ contains(matrix.os, 'ubuntu') && matrix.node_version == '10' && matrix.rust_version == 'stable' }}
+  value: ${{ contains(matrix.os, 'ubuntu') && matrix.node_version == '10' && matrix.rust_version == 'stable' }} && github.base_ref != ''
 
 # Also run on musl. That means we need to run it in a Docker container. To do that, we copy the entire job and modify its
 # strategy/matrix.
@@ -73,3 +73,6 @@
 # We don't need to run setup-node inside of a node docker image.
 - op: remove
   path: /jobs/test-docker/steps/4
+# No need to check test coverage here, since we do it in the first matrix build.
+- op: remove
+  path: /jobs/test-docker/steps/8

--- a/.github/typescript-ci-patch.yaml
+++ b/.github/typescript-ci-patch.yaml
@@ -44,7 +44,7 @@
 # Only check coverage in one of the matrix job instances.
 - op: add
   path: /jobs/test/steps/7/if
-  value: ${{ contains(matrix.os, 'ubuntu') && matrix.node_version == '10' && matrix.rust_version == 'stable' }} && github.base_ref != ''
+  value: ${{ contains(matrix.os, 'ubuntu') && matrix.node_version == '10' && matrix.rust_version == 'stable' && github.base_ref != '' }}
 
 # Also run on musl. That means we need to run it in a Docker container. To do that, we copy the entire job and modify its
 # strategy/matrix.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,7 +56,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.assets_url }}
+          upload_url: ${{ github.event.release.upload_url }}
           asset_path: bin-package/${{ steps.build.outputs.asset }}
           asset_name: ${{ steps.build.outputs.asset }}
           asset_content_type: application/gzip
@@ -96,7 +96,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.assets_url }}
+          upload_url: ${{ github.event.release.upload_url }}
           asset_path: bin-package/${{ steps.build.outputs.asset }}
           asset_name: ${{ steps.build.outputs.asset }}
           asset_content_type: application/gzip

--- a/.github/workflows/typescript-ci.yaml
+++ b/.github/workflows/typescript-ci.yaml
@@ -46,7 +46,7 @@ jobs:
       run: yarn run test
     - name: Check test coverage
       if: ${{ contains(matrix.os, 'ubuntu') && matrix.node_version == '10' && matrix.rust_version
-        == 'stable' }} && github.base_ref != ''
+        == 'stable' && github.base_ref != '' }}
       uses: anuraag016/Jest-Coverage-Diff@V1.1
       with:
         fullCoverageDiff: false

--- a/.github/workflows/typescript-ci.yaml
+++ b/.github/workflows/typescript-ci.yaml
@@ -46,7 +46,7 @@ jobs:
       run: yarn run test
     - name: Check test coverage
       if: ${{ contains(matrix.os, 'ubuntu') && matrix.node_version == '10' && matrix.rust_version
-        == 'stable' }}
+        == 'stable' }} && github.base_ref != ''
       uses: anuraag016/Jest-Coverage-Diff@V1.1
       with:
         fullCoverageDiff: false
@@ -82,12 +82,5 @@ jobs:
       run: yarn run compile
     - name: Run tests
       run: yarn run test
-    - name: Check test coverage
-      if: ${{ contains(matrix.os, 'ubuntu') && matrix.node_version == '10' && matrix.rust_version
-        == 'stable' }}
-      uses: anuraag016/Jest-Coverage-Diff@V1.1
-      with:
-        fullCoverageDiff: false
-        delta: 0.2
     container:
       image: node:${{ matrix.node_version }}-alpine


### PR DESCRIPTION
- Only run coverage once, and only if on a PR. Missed this in my original PR because the bug only occurs when running on `main`.
- Upload to the upload URL. I thought I fixed this in my original PR, but probably reverted it by mistake when I reverted hard-coded values used for testing.