### PR TITLE
First pass at adding arm64 to the build.

### DIFF
--- a/.github/typescript-ci-patch.yaml
+++ b/.github/typescript-ci-patch.yaml
@@ -62,6 +62,9 @@
   path: /jobs/test-docker/strategy/matrix/os
   value:
     - ubuntu-20.04
+- op: replace
+  path: /jobs/test/runs-on
+  value: "${{ matrix.os }}"
 - op: add
   path: /jobs/test-docker/container
   value:

--- a/.github/typescript-ci-patch.yaml
+++ b/.github/typescript-ci-patch.yaml
@@ -2,24 +2,29 @@
 - op: replace
   path: /jobs/test/strategy/matrix
   value:
-    node_version:
-      - "12"
-      - "14"
-      - "16"
-    rust_version:
+    rust_version: 
       - 1.56.0
       - stable
       - beta
-    os:
-      - macos-10.15
-      - ubuntu-20.04
-      - windows-2019
+    node_version:
+      - 12
+      - 14
+      - 16
+    system:
+      - os: macos-10.15
+        target: x86_64-apple-darwin
+      - os: macos-11
+        target: aarch64-apple-darwin
+      - os: ubuntu-20.04
+        target: x86_64-unknown-linux-gnu
+      - os: windows-2019
+        target: x86_64-pc-windows-msvc
 - op: add
   path: /jobs/test/strategy/fail-fast
   value: false
 - op: replace
   path: /jobs/test/runs-on
-  value: "${{ matrix.os }}"
+  value: "${{ matrix.system.os }}"
 
 # These steps are lifted from the Rust CI workflow, cargo-test job.
 - op: add
@@ -44,14 +49,16 @@
 # Only check coverage in one of the matrix job instances.
 - op: add
   path: /jobs/test/steps/6/if
-  value: ${{ contains(matrix.os, 'ubuntu') && matrix.node_version == '16' && matrix.rust_version == 'stable' && github.base_ref != '' }}
+  value: ${{ contains(matrix.system.os, 'ubuntu') && matrix.node_version == '16' && matrix.rust_version == 'stable' && github.base_ref != '' }}
 
 # Also run on musl. That means we need to run it in a Docker container. To do that, we copy the entire job and modify its
 # strategy/matrix.
 - op: copy
   from: /jobs/test
   path: /jobs/test-docker
-- op: replace
+- op: remove
+  path: /jobs/test-docker/strategy/matrix/system
+- op: add
   path: /jobs/test-docker/strategy/matrix/os
   value:
     - ubuntu-20.04

--- a/.github/typescript-ci-patch.yaml
+++ b/.github/typescript-ci-patch.yaml
@@ -63,7 +63,7 @@
   value:
     - ubuntu-20.04
 - op: replace
-  path: /jobs/test/runs-on
+  path: /jobs/test-docker/runs-on
   value: "${{ matrix.os }}"
 - op: add
   path: /jobs/test-docker/container

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,14 +20,68 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version:
-          - '12'
-          - '14'
-          - '16'
-        os:
-          - macos-10.15
-          - ubuntu-20.04
-          - windows-2019
+        include:
+          - os: macos-10.15
+            node_version: 12
+            target: x86_64-apple-darwin
+            pre_gyp_platform: darwin
+            pre_gyp_arch: x64
+          - os: macos-10.15
+            node_version: 14
+            target: x86_64-apple-darwin
+            pre_gyp_platform: darwin
+            pre_gyp_arch: x64
+          - os: macos-10.15
+            node_version: 16
+            target: x86_64-apple-darwin
+            pre_gyp_platform: darwin
+            pre_gyp_arch: x64
+          - os: macos-11
+            node_version: 12
+            target: aarch64-apple-darwin
+            pre_gyp_platform: darwin
+            pre_gyp_arch: arm64
+          - os: macos-11
+            node_version: 14
+            target: aarch64-apple-darwin
+            pre_gyp_platform: darwin
+            pre_gyp_arch: arm64
+          - os: macos-11
+            node_version: 16
+            target: aarch64-apple-darwin
+            pre_gyp_platform: darwin
+            pre_gyp_arch: arm64
+          - os: ubuntu-20.04
+            node_version: 12
+            target: x86_64-unknown-linux-gnu
+            pre_gyp_platform: linux
+            pre_gyp_arch: x64
+          - os: ubuntu-20.04
+            node_version: 14
+            target: x86_64-unknown-linux-gnu
+            pre_gyp_platform: linux
+            pre_gyp_arch: x64
+          - os: ubuntu-20.04
+            node_version: 16
+            target: x86_64-unknown-linux-gnu
+            pre_gyp_platform: linux
+            pre_gyp_arch: x64
+          - os: windows-2019
+            node_version: 12
+            target: x86_64-pc-windows-msvc
+            pre_gyp_platform: win32 
+            pre_gyp_arch: x64
+          - os: windows-2019
+            node_version: 14
+            target: x86_64-pc-windows-msvc
+            pre_gyp_platform: win32
+            pre_gyp_arch: x64
+          - os: windows-2019
+            node_version: 16
+            target: x86_64-pc-windows-msvc
+            pre_gyp_platform: win32 
+            pre_gyp_arch: x64
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -40,6 +94,8 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+          target: ${{ matrix.target }}
+          default: true
           override: true
       - name: Install modules
         run: yarn install --ignore-scripts
@@ -47,6 +103,9 @@ jobs:
         id: build
         # Use bash, even on Windows.
         shell: bash
+        env:
+          PRE_GYP_PLATFORM: ${{ matrix.pre_gyp_platform }}
+          PRE_GYP_ARCH: ${{ matrix.pre_gyp_arch }}
         run: |
           node publish.js
           cd bin-package

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,72 +16,26 @@ env:
 
 jobs:
   publish-github:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.system.os }}
     strategy:
       fail-fast: false
       matrix:
-        include:
+        node_version:
+          - 12
+          - 14
+          - 16
+        system:
           - os: macos-10.15
-            node_version: 12
             target: x86_64-apple-darwin
-            pre_gyp_platform: darwin
-            pre_gyp_arch: x64
-          - os: macos-10.15
-            node_version: 14
-            target: x86_64-apple-darwin
-            pre_gyp_platform: darwin
-            pre_gyp_arch: x64
-          - os: macos-10.15
-            node_version: 16
-            target: x86_64-apple-darwin
-            pre_gyp_platform: darwin
-            pre_gyp_arch: x64
           - os: macos-11
-            node_version: 12
             target: aarch64-apple-darwin
-            pre_gyp_platform: darwin
-            pre_gyp_arch: arm64
-          - os: macos-11
-            node_version: 14
-            target: aarch64-apple-darwin
-            pre_gyp_platform: darwin
-            pre_gyp_arch: arm64
-          - os: macos-11
-            node_version: 16
-            target: aarch64-apple-darwin
+            # only needed in this case, where we're cross compiling until runners with m1 chips exist
             pre_gyp_platform: darwin
             pre_gyp_arch: arm64
           - os: ubuntu-20.04
-            node_version: 12
             target: x86_64-unknown-linux-gnu
-            pre_gyp_platform: linux
-            pre_gyp_arch: x64
-          - os: ubuntu-20.04
-            node_version: 14
-            target: x86_64-unknown-linux-gnu
-            pre_gyp_platform: linux
-            pre_gyp_arch: x64
-          - os: ubuntu-20.04
-            node_version: 16
-            target: x86_64-unknown-linux-gnu
-            pre_gyp_platform: linux
-            pre_gyp_arch: x64
           - os: windows-2019
-            node_version: 12
             target: x86_64-pc-windows-msvc
-            pre_gyp_platform: win32 
-            pre_gyp_arch: x64
-          - os: windows-2019
-            node_version: 14
-            target: x86_64-pc-windows-msvc
-            pre_gyp_platform: win32
-            pre_gyp_arch: x64
-          - os: windows-2019
-            node_version: 16
-            target: x86_64-pc-windows-msvc
-            pre_gyp_platform: win32 
-            pre_gyp_arch: x64
-
     steps:
       - uses: actions/checkout@v2
         with:
@@ -94,7 +48,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          target: ${{ matrix.target }}
+          target: ${{ matrix.system.target }}
           default: true
           override: true
       - name: Install modules
@@ -104,8 +58,8 @@ jobs:
         # Use bash, even on Windows.
         shell: bash
         env:
-          PRE_GYP_PLATFORM: ${{ matrix.pre_gyp_platform }}
-          PRE_GYP_ARCH: ${{ matrix.pre_gyp_arch }}
+          PRE_GYP_PLATFORM: ${{ matrix.system.pre_gyp_platform }}
+          PRE_GYP_ARCH: ${{ matrix.system.pre_gyp_arch }}
         run: |
           node publish.js
           cd bin-package

--- a/.github/workflows/typescript-ci.yaml
+++ b/.github/workflows/typescript-ci.yaml
@@ -11,7 +11,7 @@ name: TypeScript CI
   workflow_dispatch: null
 jobs:
   test:
-    runs-on: ${{ matrix.system.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         rust_version:

--- a/.github/workflows/typescript-ci.yaml
+++ b/.github/workflows/typescript-ci.yaml
@@ -11,7 +11,7 @@ name: TypeScript CI
   workflow_dispatch: null
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.system.os }}
     strategy:
       matrix:
         rust_version:
@@ -58,7 +58,7 @@ jobs:
         delta: 0.2
         afterSwitchCommand: yarn install --ignore-scripts && yarn run compile
   test-docker:
-    runs-on: ${{ matrix.system.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         rust_version:

--- a/.github/workflows/typescript-ci.yaml
+++ b/.github/workflows/typescript-ci.yaml
@@ -11,21 +11,26 @@ name: TypeScript CI
   workflow_dispatch: null
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.system.os }}
     strategy:
       matrix:
-        node_version:
-        - '12'
-        - '14'
-        - '16'
         rust_version:
         - 1.56.0
         - stable
         - beta
-        os:
-        - macos-10.15
-        - ubuntu-20.04
-        - windows-2019
+        node_version:
+        - 12
+        - 14
+        - 16
+        system:
+        - os: macos-10.15
+          target: x86_64-apple-darwin
+        - os: macos-11
+          target: aarch64-apple-darwin
+        - os: ubuntu-20.04
+          target: x86_64-unknown-linux-gnu
+        - os: windows-2019
+          target: x86_64-pc-windows-msvc
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
@@ -45,25 +50,25 @@ jobs:
     - name: Run tests
       run: yarn run test
     - name: Check test coverage
-      if: ${{ contains(matrix.os, 'ubuntu') && matrix.node_version == '16' && matrix.rust_version
-        == 'stable' && github.base_ref != '' }}
+      if: ${{ contains(matrix.system.os, 'ubuntu') && matrix.node_version == '16'
+        && matrix.rust_version == 'stable' && github.base_ref != '' }}
       uses: anuraag016/Jest-Coverage-Diff@V1.3
       with:
         fullCoverageDiff: false
         delta: 0.2
         afterSwitchCommand: yarn install --ignore-scripts && yarn run compile
   test-docker:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.system.os }}
     strategy:
       matrix:
-        node_version:
-        - '12'
-        - '14'
-        - '16'
         rust_version:
         - 1.56.0
         - stable
         - beta
+        node_version:
+        - 12
+        - 14
+        - 16
         os:
         - ubuntu-20.04
       fail-fast: false

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "win32"
     ],
     "cpu": [
-        "x64"
+        "x64",
+        "arm64"
     ],
     "scripts": {
         "compile": "cargo-cp-artifact -a cdylib recrypt_node ./bin-package/index.node -- cargo build --release --message-format=json-render-diagnostics",

--- a/publish.js
+++ b/publish.js
@@ -45,7 +45,9 @@ fs.writeFileSync("./dist/package.json", JSON.stringify(npmPackageJson, null, 2))
 
 //Use a fully qualified path to pre-gyp binary for Windows support
 const cwd = shell.pwd().toString();
-shell.exec(`${cwd}/node_modules/@mapbox/node-pre-gyp/bin/node-pre-gyp package`);
+const replacementArch = process.env.PRE_GYP_ARCH ? `--target_arch=${process.env.PRE_GYP_ARCH}` : "";
+const replacementPlatform = process.env.PRE_GYP_PLATFORM ? `--target_platform=${process.env.PRE_GYP_PLATFORM}` : "";
+shell.exec(`${cwd}/node_modules/@mapbox/node-pre-gyp/bin/node-pre-gyp package ${replacementArch} ${replacementPlatform}`);
 var tgz = shell.exec("find ./build -name *.tar.gz");
 shell.cp(tgz, "./bin-package/");
 shell.pushd("./dist");


### PR DESCRIPTION
Both node-pre-gyp and rust need different platform and architecture
arguments since we have to cross compile. There aren't currently M1
action runners available to do this natively.

Uses rust-toolchain to set the default to the current matrix option,
need to make sure that works and that the linker used doesn't get messed
up for musl builds for ex.

This is in support of IronCoreLabs/ironnode#70