### PR TITLE
Use the GitHub CLI to upload release assets.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,14 +66,7 @@ jobs:
           cd bin-package
           echo "::set-output name=asset::$(echo *.tar.gz)"
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: bin-package/${{ steps.build.outputs.asset }}
-          asset_name: ${{ steps.build.outputs.asset }}
-          asset_content_type: application/gzip
+        run: gh release upload ${{ github.event.release.tag_name }} bin-package/${{ steps.build.outputs.asset }} --clobber
 
   publish-github-docker:
     runs-on: ubuntu-20.04
@@ -106,14 +99,7 @@ jobs:
           cd bin-package
           echo "::set-output name=asset::$(echo *.tar.gz)"
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: bin-package/${{ steps.build.outputs.asset }}
-          asset_name: ${{ steps.build.outputs.asset }}
-          asset_content_type: application/gzip
+        run: gh release upload ${{ github.event.release.tag_name }} bin-package/${{ steps.build.outputs.asset }} --clobber
 
   publish-npm:
     needs:


### PR DESCRIPTION
We're using `actions/upload-release-asset`, which is deprecated and seemingly has [random failures](https://github.com/actions/upload-release-asset/issues/69). This PR switches to using the GitHub CLI `gh` instead.