### PR TITLE
Set the GITHUB_TOKEN env var for gh release upload.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -67,6 +67,8 @@ jobs:
           echo "::set-output name=asset::$(echo *.tar.gz)"
       - name: Upload release asset
         run: gh release upload ${{ github.event.release.tag_name }} bin-package/${{ steps.build.outputs.asset }} --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-github-docker:
     runs-on: ubuntu-20.04
@@ -100,6 +102,8 @@ jobs:
           echo "::set-output name=asset::$(echo *.tar.gz)"
       - name: Upload release asset
         run: gh release upload ${{ github.event.release.tag_name }} bin-package/${{ steps.build.outputs.asset }} --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-npm:
     needs:


### PR DESCRIPTION
This is a follow up to #85 because `gh` needs `GITHUB_TOKEN` to authenticate to GitHub, and the env var isn't automatically set.