### PR TITLE
Install pip and gh in our docker builds.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -82,7 +82,8 @@ jobs:
           - '14'
           - '16'
     steps:
-      - run: apk add build-base git python3 wget
+      - run: apk add build-base git python3 wget py3-pip
+      - run: pip install gh
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Our [previous build](https://github.com/IronCoreLabs/recrypt-node-binding/runs/5147836162?check_suite_focus=true) failed because there's no `gh` client installed in the Docker containers. This PR adds pip and gh to them.