### PR TITLE
Set the safe directory (again) before upload.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -110,7 +110,9 @@ jobs:
           cd bin-package
           echo "::set-output name=asset::$(echo *.tar.gz)"
       - name: Upload release asset
-        run: gh release upload ${{ github.event.release.tag_name }} bin-package/${{ steps.build.outputs.asset }} --clobber
+        run: |
+          git config --global --add safe.directory $(pwd)
+          gh release upload ${{ github.event.release.tag_name }} bin-package/${{ steps.build.outputs.asset }} --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The underlying problem is that the docker container is running as root, but the work directory where code is checked out is owned by the github runner user. Git refuses to check out in that condition unless we specify a [`safe.directory`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory).

The `actions/checkout` action does this, but first it sets `HOME` to a temporary directory. That env dir setting only lasts for the `checkout` command, and then it disappears.

When we run the `gh` CLI, it uses git for some reason as part of the artifact upload procedure. Git doesn't know about `safe-directory`, because the previous `HOME` directory setting has been lost.

This PR adds the setting again before we run `gh`.