### PR TITLE
Further fixes to the publish workflow.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -134,10 +134,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.release.tag_name }}
-      - uses: c-hive/gha-yarn-cache@v1
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: 16
+          cache: yarn
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
The previous PRs (#122, #123) allowed testing most of the publish workflow without actually publishing a release. The only part of the workflow that wasn't testable is the part that failed. This PR fixes it.