### PR TITLE
Add support for Node 21

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,6 +30,7 @@ jobs:
           - 16
           - 18
           - 20
+          - 21
         system:
           - os: macos-12
             target: x86_64-apple-darwin
@@ -91,6 +92,7 @@ jobs:
           - 16
           - 18
           - 20
+          - 21
         os:
           - buildjet-2vcpu-ubuntu-2204
           - buildjet-4vcpu-ubuntu-2204-arm
@@ -136,7 +138,7 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/typescript-napi-ci.yaml
+++ b/.github/workflows/typescript-napi-ci.yaml
@@ -17,9 +17,11 @@ jobs:
         - stable
         - beta
         node_version:
-        - 16
+        - 16 # remove when 22 LTS is out
         - 18
         - 20
+        # explicitly asked for, we normally don't support non-LTS versions. Remove when Node support is dropped.
+        - 21 
         system:
         - os: macos-12
           target: x86_64-apple-darwin
@@ -78,6 +80,7 @@ jobs:
         - 16
         - 18
         - 20
+        - 21
         os:
         - buildjet-2vcpu-ubuntu-2204
         - buildjet-4vcpu-ubuntu-2204-arm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.1
+
+### Changed
+
+- Added support for Node 21 by request. We don't normally support non-LTS Node versions, and this will be dropped when Node drops maintenance support for it.
+
 ## 0.10.0
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ This library uses the [Neon Bindings](https://www.neon-bindings.com) toolchain t
 
 ## Supported Platforms
 
-|                         | Node 16 | Node 18 | Node 20 |
-| ----------------------- | ------- | ------- | ------- |
-| Linux x64 - glibc       | ✓       | ✓       | ✓       |
-| Linux x64 - musl-libc   | ✓       | ✓       | ✓       |
-| Linux arm64 - glibc     | ✓       | ✓       | ✓       |
-| Linux arm64 - musl-libc | ✓       | ✓       | ✓       |
-| OSX x64                 | ✓       | ✓       | ✓       |
-| OSX arm64               | ✓       | ✓       | ✓       |
-| Windows x64             | ✓       | ✓       | ✓       |
+|                         | Node 16 | Node 18 | Node 20 | Node 21 |
+| ----------------------- | ------- | ------- | ------- | ------- |
+| Linux x64 - glibc       | ✓       | ✓       | ✓       | ✓       |
+| Linux x64 - musl-libc   | ✓       | ✓       | ✓       | ✓       |
+| Linux arm64 - glibc     | ✓       | ✓       | ✓       | ✓       |
+| Linux arm64 - musl-libc | ✓       | ✓       | ✓       | ✓       |
+| OSX x64                 | ✓       | ✓       | ✓       | ✓       |
+| OSX arm64               | ✓       | ✓       | ✓       | ✓       |
+| Windows x64             | ✓       | ✓       | ✓       | ✓       |
 
 ## Install
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -16,12 +19,15 @@
       }
     },
     "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -32,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668086072,
-        "narHash": "sha256-msFoXI5ThCmhTTqgl27hpCXWhaeqxphBaleJAgD8JYM=",
+        "lastModified": 1701626906,
+        "narHash": "sha256-ugr1QyzzwNk505ICE4VMQzonHQ9QS5W33xF2FXzFQ00=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "72d8853228c9758820c39b8659415b6d89279493",
+        "rev": "0c6d8c783336a59f4c59d4a6daed6ab269c4b361",
         "type": "github"
       },
       "original": {
@@ -46,11 +52,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1665296151,
-        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
         "type": "github"
       },
       "original": {
@@ -73,16 +79,46 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1668134765,
-        "narHash": "sha256-pPTpucjGejrv5aYBj1PElWl2SV//wmTUeGfyzakmqKM=",
+        "lastModified": 1701656211,
+        "narHash": "sha256-lfFXsLWH4hVbEKR6K+UcDiKxeS6Lz4FkC1DZ9LHqf9Y=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d9917a612b3d09f26f0ead5b793009a9f6047c16",
+        "rev": "47a276e820ae4ae1b8d98a503bf09d2ceb52dfd8",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
-  outputs = { self, nixpkgs, rust-overlay, flake-utils}:
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         lib = import <nixpkgs/lib>;
@@ -15,12 +15,12 @@
       rec {
         devShell = pkgs.mkShell {
           buildInputs = with pkgs.nodePackages; [
-            pkgs.nodejs-18_x
-            (pkgs.yarn.override { nodejs = pkgs.nodejs-18_x; })
+            pkgs.nodejs_20
+            (pkgs.yarn.override { nodejs = pkgs.nodejs_20; })
             pkgs.libiconv
           ];
           nativeBuildInputs = [ pkgs.rust-bin.stable.latest.default ]
-              ++ pkgs.lib.optionals (pkgs.stdenv.isDarwin) [ pkgs.darwin.cctools ];
+            ++ pkgs.lib.optionals (pkgs.stdenv.isDarwin) [ pkgs.darwin.cctools ];
         };
       });
 }


### PR DESCRIPTION
We don't support non-LTS versions normally but 21 was requested (#131). We'll support it through at least its Node maintenence window, where it'll be at risk of being dropped in any major version bump.